### PR TITLE
fix building error

### DIFF
--- a/Sources/HttpParser.swift
+++ b/Sources/HttpParser.swift
@@ -40,7 +40,9 @@ public class HttpParser {
         guard url.endIndex > queryStart else {
             return []
         }
-        let query = String(url[queryStart..<url.endIndex])
+        guard let query = String(url[queryStart..<url.endIndex]) else {
+            return []        
+        }
         return query.components(separatedBy: "&")
             .reduce([(String, String)]()) { (c, s) -> [(String, String)] in
                 guard let nameEndIndex = s.index(of: "=") else {


### PR DESCRIPTION
There is an error happened when building with swift 4, I found it caused by type of the variable query is optional, need to unwrap the variable.

building target: MacOS
Xcode: 9.1
swift: 4.0.2